### PR TITLE
Show that a 1 is Rolled instead of hiding the dice

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,7 +152,6 @@ function checkWinner() {
 function changeActiveState() {
     document.querySelector('.player-0-panel').classList.toggle('active');
     document.querySelector('.player-1-panel').classList.toggle('active');
-    document.querySelector('.dice').style.display = 'none'
 }
 
 function looseScore() {

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ SOFTWARE. -->
             <button class="btn-roll"><i class="ion-ios-loop"></i>Roll dice</button>
             <button class="btn-hold"><i class="ion-ios-download-outline"></i>Hold</button>
             <!-- deletion of dice in alt -->
-            <img src="images/dice-5.png" alt="" class="dice"> 
+            <img src="" alt="" class="dice"> 
         </div>
         
         <script src="app.js"></script>


### PR DESCRIPTION
Relates to #49 

Changes makes it so that the dice is not hidden after switching player panels. 

Also removed `src` from `img` tag in html to prevent double die render on first roll.